### PR TITLE
fix: enforce numbers on NumberInput 

### DIFF
--- a/src/others/components/NumberInput.tsx
+++ b/src/others/components/NumberInput.tsx
@@ -21,7 +21,7 @@ export const NumberInput: React.FunctionComponent<NumberInputProps> = ({ value, 
 
       onChange(Math.min(maxVal, Math.max(minVal, parseInt(event.target.value) || 0)));
     },
-    [onChange]
+    [onChange, maxVal, minVal]
   );
   return (
     <span className={styles.wrapper}>


### PR DESCRIPTION
https://linear.app/ugt/issue/S3-26/[fe-or-people-count]-set-the-field-to-enter-number-only-for-filling-no

- Enforce numeric keyboard
- Leverage HTML 5 min/max
- Refuse input that are not integers