### PR TITLE
feat: store selected language

### DIFF
--- a/src/others/components/LanguageSelector.tsx
+++ b/src/others/components/LanguageSelector.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import styles from "./LanguageSelector.module.css";
 
 import { HeaderCard } from "./Header";
-import { AvailableLang, availableLangs } from "../contexts/i18n";
+import { AvailableLang, availableLangs, storeLanguage } from "../contexts/i18n";
 import { ImgFlagUk } from "../../medias/images/UGT_Asset_FlagSelector_UKR";
 import { ImgFlagEn } from "../../medias/images/UGT_Asset_FlagSelector_ENG";
 import { ImgDropdown } from "../../medias/images/UGT_Asset_UI_Dropdown";
@@ -55,6 +55,7 @@ export const LanguageSelector: React.FunctionComponent<LanguageSelectorProps> = 
 
   const selectLang = (lang: string) => {
     i18n.changeLanguage(lang);
+    storeLanguage(lang as AvailableLang);
     setExpanded(false);
   };
 

--- a/src/others/contexts/i18n.tsx
+++ b/src/others/contexts/i18n.tsx
@@ -27,7 +27,10 @@ function getInitLang(): AvailableLang {
     // This is done because the majority of users is ukrainian and there seem to
     // be users with their browser settings pointing to en while preferring uk.
     for (let lang of languagePriority) {
-      if (browserLangs.includes(lang)) choice = lang;
+      if (browserLangs.includes(lang)) {
+        choice = lang;
+        break;
+      }
     }
   }
   storeLanguage(choice);

--- a/src/others/contexts/i18n.tsx
+++ b/src/others/contexts/i18n.tsx
@@ -16,7 +16,7 @@ const languagePriority: AvailableLang[] = ["uk", "en"];
 export const availableLangs = Object.keys(resources).sort();
 
 function getInitLang(): AvailableLang {
-  let choice: AvailableLang | undefined = undefined;
+  let choice: AvailableLang = "uk";
   const prevSession = localStorage.getItem("languageSetting");
   if (prevSession != null && availableLangs.includes(prevSession)) {
     // use language from previous session
@@ -30,14 +30,11 @@ function getInitLang(): AvailableLang {
       if (browserLangs.includes(lang)) choice = lang;
     }
   }
-  // default to uk
-  choice = choice || "uk";
   storeLanguage(choice);
   return choice;
 }
 
 export function storeLanguage(language: AvailableLang) {
-  if (!availableLangs.includes(language)) return;
   localStorage.setItem("languageSetting", language);
 }
 

--- a/src/others/contexts/i18n.tsx
+++ b/src/others/contexts/i18n.tsx
@@ -11,11 +11,34 @@ const resources = {
 
 export type AvailableLang = "en" | "uk";
 
+const languagePriority: AvailableLang[] = ["uk", "en"];
+
 export const availableLangs = Object.keys(resources).sort();
 
-function getInitLang() {
-  const browserLang = navigator.language.split("-")[0].toLowerCase();
-  return availableLangs.includes(browserLang) ? browserLang : "uk";
+function getInitLang(): AvailableLang {
+  let choice: AvailableLang | undefined = undefined;
+  const prevSession = localStorage.getItem("languageSetting");
+  if (prevSession != null && availableLangs.includes(prevSession)) {
+    // use language from previous session
+    choice = prevSession as AvailableLang;
+  } else {
+    const browserLangs = navigator.languages.map((lang) => lang.split("-")[0].toLowerCase());
+    // Pick first language from `languagePriority` occurring in browser settings.
+    // This is done because the majority of users is ukrainian and there seem to
+    // be users with their browser settings pointing to en while preferring uk.
+    for (let lang of languagePriority) {
+      if (browserLangs.includes(lang)) choice = lang;
+    }
+  }
+  // default to uk
+  choice = choice || "uk";
+  storeLanguage(choice);
+  return choice;
+}
+
+export function storeLanguage(language: AvailableLang) {
+  if (!availableLangs.includes(language)) return;
+  localStorage.setItem("languageSetting", language);
 }
 
 i18n


### PR DESCRIPTION
See [this ticket](https://linear.app/ugt/issue/S3-39/store-language-selection).

- store selected language for future sessions
- change strategy for picking initial language
  - uk/ua if present in `navigator.languages` and as fallback
  - en if present in `navigator.languages` and uk/ua not present in `navigator.languages`